### PR TITLE
Mobile base integration

### DIFF
--- a/reachy_pyluos_hal/reachy.py
+++ b/reachy_pyluos_hal/reachy.py
@@ -26,7 +26,10 @@ class Reachy(GateProtocol):
     """Reachy wrapper around serial GateClients which handle the communication with the hardware."""
 
     if sys.platform == 'linux':
-        port_template: str = '/dev/ttyUSB*'
+        if glob('/dev/gate*') == []:
+            port_template: str = '/dev/ttyUSB*'
+        else:
+            port_template: str = '/dev/gate*'
     elif sys.platform == 'darwin':
         port_template: str = '/dev/tty.usbserial*'
     elif sys.platform == 'win32':

--- a/reachy_pyluos_hal/reachy.py
+++ b/reachy_pyluos_hal/reachy.py
@@ -26,7 +26,7 @@ class Reachy(GateProtocol):
     """Reachy wrapper around serial GateClients which handle the communication with the hardware."""
 
     if sys.platform == 'linux':
-        if glob('/dev/gate*') == []:
+        if len(glob('/dev/gate*')) == 0:
             port_template: str = '/dev/ttyUSB*'
         else:
             port_template: str = '/dev/gate*'

--- a/reachy_pyluos_hal/tools/reachy_identify_model.py
+++ b/reachy_pyluos_hal/tools/reachy_identify_model.py
@@ -43,7 +43,7 @@ def print_model_and_leave(model: str):
 
 
 def zuuu_config():
-    """Run model identification checks on the mobile base"""
+    """Run model identification checks on the mobile base."""
     config = get_reachy_config()
 
     if config is not None and 'zuuu_model' in config:

--- a/reachy_pyluos_hal/tools/reachy_identify_model.py
+++ b/reachy_pyluos_hal/tools/reachy_identify_model.py
@@ -33,12 +33,24 @@ from reachy_pyluos_hal.config import get_reachy_config
 
 
 DEFAULT_MODEL = 'full_kit'
+DEFAULT_ZUUU_MODEL = 'None'
 
 
 def print_model_and_leave(model: str):
     """Print the model found on stdout and exit."""
     print(model)
     sys.exit(0)
+
+
+def zuuu_config():
+    """Run model identification checks on the mobile base"""
+    config = get_reachy_config()
+
+    if config is not None and 'zuuu_model' in config:
+        model = config['zuuu_model']
+        print_model_and_leave(model)
+    else:
+        print_model_and_leave(DEFAULT_ZUUU_MODEL)
 
 
 def main():
@@ -61,3 +73,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+    zuuu_config()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'dynamixel-config=reachy_pyluos_hal.tools.dynamixel_config:main',
             'reachy-dynamixel-config=reachy_pyluos_hal.tools.reachy_dynamixel_config:main',
             'reachy-identify-model=reachy_pyluos_hal.tools.reachy_identify_model:main',
+            'reachy-identify-zuuu-model=reachy_pyluos_hal.tools.reachy_identify_model:zuuu_config',
         ],
     },
 


### PR DESCRIPTION
- Add script to get the mobile base version
- Connect to Reachy's gates using udev rules on *'/dev/gates\*'*, if the udev is defined.
Udev rules were needed because the mobile base's Lidar is also on *'/dev/ttyUSB\*'* and searching for the gates on *'/dev/ttyUSB\*'* was causing connection issues.